### PR TITLE
Switch to the more modern `thiserror` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,7 @@ name = "filecheck"
 
 [dependencies]
 regex = "1"
-failure = "0.1.1"
-failure_derive = "0.1.1"
+thiserror = "1"
 
 [badges]
 maintenance = { status = "passively-maintained" }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,21 +1,20 @@
-use regex;
-use std::convert::From;
 use std::result;
+use thiserror::Error;
 
 /// A result from the filecheck library.
 pub type Result<T> = result::Result<T, Error>;
 
 /// A filecheck error.
-#[derive(Fail, Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
     /// A syntax error in a check line.
-    #[fail(display = "{}", _0)]
+    #[error("{0}")]
     Syntax(String),
     /// A check refers to an undefined variable.
     ///
     /// The pattern contains `$foo` where the `foo` variable has not yet been defined.
     /// Use `$$` to match a literal dollar sign.
-    #[fail(display = "{}", _0)]
+    #[error("{0}")]
     UndefVariable(String),
     /// A pattern contains a back-reference to a variable that was defined in the same pattern.
     ///
@@ -26,20 +25,14 @@ pub enum Error {
     /// check: Hello $(world=[^ ]*)
     /// sameln: $world
     /// ```
-    #[fail(display = "{}", _0)]
+    #[error("{0}")]
     Backref(String),
     /// A pattern contains multiple definitions of the same variable.
-    #[fail(display = "{}", _0)]
+    #[error("{0}")]
     DuplicateDef(String),
     /// An error in a regular expression.
     ///
     /// Use `cause()` to get the underlying `Regex` library error.
-    #[fail(display = "{}", _0)]
-    Regex(#[cause] regex::Error),
-}
-
-impl From<regex::Error> for Error {
-    fn from(e: regex::Error) -> Error {
-        Error::Regex(e)
-    }
+    #[error("{0}")]
+    Regex(#[from] regex::Error),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,9 +242,6 @@ pub use checker::{Checker, CheckerBuilder};
 pub use error::{Error, Result};
 pub use variable::{Value, VariableMap, NO_VARIABLES};
 
-#[macro_use]
-extern crate failure_derive;
-
 mod checker;
 mod error;
 mod explain;


### PR DESCRIPTION
This commit removes the dependency on `failure` and `failure_derive` in
favor of the more modern `thiserror` crate. This is intended to
hopefully bring build-time wins to wasmtime because `failure_derive`
depends on `synstructure` which enables lots of features of `syn`. This
means that if you alternate between `cargo build` and `cargo test`
features are changing and lots of rebuilds happen when this crate is
conditionally depended on in tests (as it often is).